### PR TITLE
Added information so that the JAR can act as an OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,32 @@
             </plugin>
 
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <archive>  
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive> 
+                </configuration>
+            </plugin>  
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.2.0</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>    
+                            <goal>manifest</goal>
+                        </goals>   
+                    </execution>
+                </executions>                
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version>
                 <executions>


### PR DESCRIPTION
The CXF Swagger implementation includes functionality to show the Swagger UI:

http://cxf.apache.org/docs/swagger2feature.html#Swagger2Feature-AutomaticUIActivation

This can only work though if the webjars swagger-ui jar is installed as an OSGi bundle.